### PR TITLE
Fix build for M1 Macs (include arm64 simulator slice)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ file ZKSyncCrypto/libzks/libzkscrypto.a
 rm -rf ZKSyncCrypto.xcarchive
 
 xcodebuild clean archive \
-            ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO \
+            ONLY_ACTIVE_ARCH=NO \
             -configuration Release \
             -sdk iphonesimulator \
             -project ZKSyncCrypto.xcodeproj \
@@ -19,7 +19,7 @@ xcodebuild clean archive \
             -archivePath ZKSyncCrypto.xcarchive \
             SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
-rm -rf x86_64 
+rm -rf x86_64
 mkdir x86_64
 
 cp -r ZKSyncCrypto.xcarchive/Products/Library/Frameworks/ZKSyncCrypto.framework x86_64/ZKSyncCrypto.framework
@@ -36,17 +36,17 @@ xcodebuild clean archive \
             -archivePath ZKSyncCrypto.xcarchive \
             SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
-rm -rf amr64 
-mkdir amr64
+rm -rf arm64
+mkdir arm64
 
-cp -r ZKSyncCrypto.xcarchive/Products/Library/Frameworks/ZKSyncCrypto.framework amr64/ZKSyncCrypto.framework
-file amr64/ZKSyncCrypto.framework/ZKSyncCrypto
+cp -r ZKSyncCrypto.xcarchive/Products/Library/Frameworks/ZKSyncCrypto.framework arm64/ZKSyncCrypto.framework
+file arm64/ZKSyncCrypto.framework/ZKSyncCrypto
 
 rm -rf ZKSyncCrypto.xcframework
 
 xcodebuild -create-xcframework \
             -framework x86_64/ZKSyncCrypto.framework \
-            -framework amr64/ZKSyncCrypto.framework \
+            -framework arm64/ZKSyncCrypto.framework \
             -output ZKSyncCrypto.xcframework
 
 file ZKSyncCrypto.xcframework
@@ -58,11 +58,11 @@ mkdir ${DEPENDENCIES_FOLDER}
 cp -r ZKSyncCrypto.xcframework ${DEPENDENCIES_FOLDER}
 
 rm -rf x86_64
-rm -rf amr64
+rm -rf arm64
 rm -rf ZKSyncCrypto.xcarchive
 rm -rf ZKSyncCrypto.xcframework
 
-# Workaround, which allows to fix build-related issue, which happens when xcframework 
+# Workaround, which allows to fix build-related issue, which happens when xcframework
 # name is similar to class name, which resides in this xcframework. More information can be found here:
 # https://developer.apple.com/forums/thread/123253
 cd ${DEPENDENCIES_FOLDER}/ZKSyncCrypto.xcframework

--- a/build.sh
+++ b/build.sh
@@ -19,11 +19,11 @@ xcodebuild clean archive \
             -archivePath ZKSyncCrypto.xcarchive \
             SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
-rm -rf x86_64
-mkdir x86_64
+rm -rf arm64_x86_64
+mkdir arm64_x86_64
 
-cp -r ZKSyncCrypto.xcarchive/Products/Library/Frameworks/ZKSyncCrypto.framework x86_64/ZKSyncCrypto.framework
-file x86_64/ZKSyncCrypto.framework/ZKSyncCrypto
+cp -r ZKSyncCrypto.xcarchive/Products/Library/Frameworks/ZKSyncCrypto.framework arm64_x86_64/ZKSyncCrypto.framework
+file arm64_x86_64/ZKSyncCrypto.framework/ZKSyncCrypto
 
 rm -rf ZKSyncCrypto.xcarchive
 
@@ -45,7 +45,7 @@ file arm64/ZKSyncCrypto.framework/ZKSyncCrypto
 rm -rf ZKSyncCrypto.xcframework
 
 xcodebuild -create-xcframework \
-            -framework x86_64/ZKSyncCrypto.framework \
+            -framework arm64_x86_64/ZKSyncCrypto.framework \
             -framework arm64/ZKSyncCrypto.framework \
             -output ZKSyncCrypto.xcframework
 
@@ -57,7 +57,7 @@ rm -rf ${DEPENDENCIES_FOLDER}
 mkdir ${DEPENDENCIES_FOLDER}
 cp -r ZKSyncCrypto.xcframework ${DEPENDENCIES_FOLDER}
 
-rm -rf x86_64
+rm -rf arm64_x86_64
 rm -rf arm64
 rm -rf ZKSyncCrypto.xcarchive
 rm -rf ZKSyncCrypto.xcframework


### PR DESCRIPTION
* replace amr64 directory name with arm64
* remove `ARCHS` option from simulator build so that arm64 slice is also built.